### PR TITLE
Pathways can be "tagged" for easy classification

### DIFF
--- a/server/src/db/queries/pathway/createUpdatePathway.js
+++ b/server/src/db/queries/pathway/createUpdatePathway.js
@@ -1,7 +1,7 @@
 const Query = require('../../core/Query')
 const Model = require('../../core/Model')
 
-const createUpdatePathway = ({id, name, steps}) => {
+const createUpdatePathway = ({ id, name, steps, tags }) => {
     return new Query({
         statement: `
         MERGE (p:Pathway {id: $id})
@@ -42,6 +42,9 @@ const createUpdatePathway = ({id, name, steps}) => {
             }
         )
         YIELD value
+        UNWIND $tags as tag
+        MERGE (t:Tag {name: tag})
+        MERGE (p)-[r:HAS_TAG]->(t)
         WITH DISTINCT p
         RETURN p.id
         `,
@@ -49,7 +52,8 @@ const createUpdatePathway = ({id, name, steps}) => {
             id,
             name,
             steps,
-        }
+            tags,
+        },
     })
 }
 

--- a/server/src/graphql/resolvers/pathway.js
+++ b/server/src/graphql/resolvers/pathway.js
@@ -1,20 +1,22 @@
-const queries = require("../../db/queries/queries")
-const github = require("../../utils/github")
+const queries = require('../../db/queries/queries')
+const github = require('../../utils/github')
 
 const resolver = {
     Mutation: {
-        async createUpdatePathway(_, { id, name, steps }) {
+        async createUpdatePathway(_, { id, name, steps, tags }) {
+            console.log(tags)
             const query = queries.pathway.createUpdatePathway({
                 id,
                 name,
                 steps,
+                tags,
             })
 
             try {
                 await query.run()
-                return { status: "OK", message: null }
+                return { status: 'OK', message: null }
             } catch (e) {
-                return { status: "ERROR", message: e.toString() }
+                return { status: 'ERROR', message: e.toString() }
             }
         },
         async deletePathway(_, { id, steps, whole }) {
@@ -26,9 +28,9 @@ const resolver = {
 
             try {
                 await query.run()
-                return { status: "OK", message: null }
+                return { status: 'OK', message: null }
             } catch (e) {
-                return { status: "ERROR", message: e.toString() }
+                return { status: 'ERROR', message: e.toString() }
             }
         },
         async createUpdateContent(_, { id, title, content }, context) {
@@ -51,9 +53,9 @@ const resolver = {
                     author_email: context.user.email,
                 })
 
-                return { status: "OK", message: null }
+                return { status: 'OK', message: null }
             } catch (e) {
-                return { status: "ERROR", message: e.toString() }
+                return { status: 'ERROR', message: e.toString() }
             }
         },
         async forkContent(_, { id, title, content, stepId }, context) {
@@ -78,9 +80,9 @@ const resolver = {
                     author_email: context.user.email,
                 })
 
-                return { status: "OK", message: null }
+                return { status: 'OK', message: null }
             } catch (e) {
-                return { status: "ERROR", message: e.toString() }
+                return { status: 'ERROR', message: e.toString() }
             }
         },
     },

--- a/server/src/graphql/typedefs/pathway.graphql
+++ b/server/src/graphql/typedefs/pathway.graphql
@@ -1,6 +1,7 @@
 type Pathway {
     id: String
     name: String
+    tags: [Tag] @relation(name: "HAS_TAG", direction: "OUT")
     steps: [Step] @relation(name: "HAS_PARENT_PATHWAY", direction: "IN")
 }
 
@@ -8,6 +9,11 @@ type Content {
     id: String
     title: String
     content: String
+}
+
+type Tag {
+  name: String
+  pathways: [Pathway] @relation(name: "HAS_TAG", direction: "IN")
 }
 
 
@@ -45,6 +51,7 @@ type Mutation {
         id: String!
         name: String!
         steps: [StepPayload]!
+        tags: [String]
     ): StatusMessage
     deletePathway(
         id: String!


### PR DESCRIPTION
Pathways can have one or more tags for easy classification. For example, a React Pathway can have the following tags: `#frontend, #javascript, #react`.

For querying the tags on a pathway: 
```graphql
query {
  Pathway {
    id
    name
    tags {
      name
    }
  }
}
```

For querying all Pathways with a given tag:
```graphql
query {
  Tag(name: "tag-name") {
    pathways {
      id
      name
    }
  }
}
```

And finally, to create a Pathway with given tags:

```graphql
mutation {
  createUpdatePathway(
    id: "Pathway_111"
    name: "Tagged Pathway"
    steps: [ ... ]
    tags: ["tag-1", "tag-2"]
  ) {
    status
    message
  }
}
```